### PR TITLE
Avoid fetching implementation ContractData for the main proxy, since we already have the necessary V1 and V2 ContractData

### DIFF
--- a/diffusc/core/fork_mode.py
+++ b/diffusc/core/fork_mode.py
@@ -201,7 +201,12 @@ class ForkMode(AnalysisMode):
             )
             if is_address(self._proxy_address):
                 self._proxy = get_contract_data_from_address(
-                    self._proxy_address, "", self._provider, self.net_info
+                    self._proxy_address,
+                    "",
+                    self._provider,
+                    self.net_info,
+                    is_main_proxy=True,
+                    main_proxy_impl=self._v2,
                 )
                 if not self._proxy["valid_data"]:
                     CryticPrint.print_error(

--- a/diffusc/core/hybrid_mode.py
+++ b/diffusc/core/hybrid_mode.py
@@ -213,7 +213,12 @@ class HybridMode(AnalysisMode):
             )
             if is_address(self._proxy_address):
                 self._proxy = get_contract_data_from_address(
-                    self._proxy_address, "", self._network_provider, self.net_info
+                    self._proxy_address,
+                    "",
+                    self._network_provider,
+                    self.net_info,
+                    is_main_proxy=True,
+                    main_proxy_impl=self._v2,
                 )
                 if not self._proxy["valid_data"]:
                     CryticPrint.print_error(

--- a/diffusc/utils/from_address.py
+++ b/diffusc/utils/from_address.py
@@ -60,6 +60,7 @@ def get_deployed_contract(
     return contract, impl_slither, impl_contract
 
 
+# pylint: disable=too-many-arguments
 def get_contract_data_from_address(
     address: str,
     implementation: str,

--- a/diffusc/utils/from_address.py
+++ b/diffusc/utils/from_address.py
@@ -23,6 +23,7 @@ def get_deployed_contract(
     implementation: str,
     slither_provider: NetworkSlitherProvider,
     network_info: NetworkInfoProvider,
+    is_main_proxy: bool = False,
 ) -> tuple[Contract, Slither | None, Contract | None]:
     """Get deployed contract ABI from Slither
     Will get the correct implementation if the contract is a proxy
@@ -36,7 +37,7 @@ def get_deployed_contract(
     impl_slither = None
     impl_contract = None
 
-    if contract.is_upgradeable_proxy:
+    if contract.is_upgradeable_proxy and not is_main_proxy:
         if implementation == "":
             implementation, contract_data = network_info.get_proxy_implementation(
                 contract, contract_data
@@ -65,6 +66,8 @@ def get_contract_data_from_address(
     slither_provider: NetworkSlitherProvider,
     network_info: NetworkInfoProvider,
     suffix: str = "",
+    is_main_proxy: bool = False,
+    main_proxy_impl: ContractData = None
 ) -> ContractData:
     """Get a ContractData object from a network address, including Slither object."""
 
@@ -88,19 +91,25 @@ def get_contract_data_from_address(
 
     if contract_data["valid_data"]:
         contract, impl_slither, impl_contract = get_deployed_contract(
-            contract_data, implementation, slither_provider, network_info
+            contract_data, implementation, slither_provider, network_info, is_main_proxy
         )
         contract_data["contract_object"] = contract
 
-        if impl_slither and impl_contract:
+        if (impl_slither and impl_contract) or is_main_proxy:
             contract_data["is_proxy"] = True
+            if is_main_proxy and main_proxy_impl:
+                impl_contract = main_proxy_impl["contract_object"]
+                impl_slither = main_proxy_impl["slither"]
             contract_data["implementation_slither"] = impl_slither
             contract_data["implementation_object"] = impl_contract
             contract_data["implementation_slot"] = get_proxy_implementation_slot(contract)
             if contract_data["implementation_slot"] is None:
                 _, proxy_data = network_info.get_proxy_implementation(contract, contract_data)
                 contract_data["implementation_slot"] = proxy_data["implementation_slot"]
-            contract_data["is_erc20"] = impl_contract.is_erc20()
+            if impl_contract:
+                contract_data["is_erc20"] = impl_contract.is_erc20()
+            else:
+                contract_data["is_erc20"] = False
             if implementation != "":
                 contract_data["contract_object"] = contract_data["implementation_object"]
                 contract_data["slither"] = contract_data["implementation_slither"]

--- a/diffusc/utils/from_address.py
+++ b/diffusc/utils/from_address.py
@@ -68,7 +68,7 @@ def get_contract_data_from_address(
     network_info: NetworkInfoProvider,
     suffix: str = "",
     is_main_proxy: bool = False,
-    main_proxy_impl: ContractData = None
+    main_proxy_impl: ContractData = None,
 ) -> ContractData:
     """Get a ContractData object from a network address, including Slither object."""
 


### PR DESCRIPTION
Adds optional `is_main_proxy` and `main_proxy_impl` arguments to `get_contract_data_from_address`, and uses them when getting the ContractData for the main proxy given via the `-p` argument.

Fetching the proxy's implementation ContractData based on the current implementation is helpful for additional targets which are also proxies, but for the main proxy we already have the necessary V1 and V2 ContractData. Fetching the current implementation's data only adds more overhead to the static analysis, and in cases like the malicious Ankr upgrade, trying to fetch the current implementation on chain causes Hybrid Mode to fail, since the current implementation is still unverified.

Tl;dr: now we can run: 
```
diffusc 0x9E6616089E3d78FaA9B6A1361b67E562C1600871 ./contracts/implementation/ankr/AnkrBNBRewardCertificate/contracts/upgrades/aBNBc_Malicious.sol -p 0xe85afccdafbe7f2b096f268e31cce3da8da2990a -v 0.8.16 -n bsc
```