### PR TITLE
Dev update pytests

### DIFF
--- a/diffusc/tests/unit/utils/test_helpers.py
+++ b/diffusc/tests/unit/utils/test_helpers.py
@@ -12,10 +12,10 @@ def test_pragma_from_file() -> None:
 
     file = os.path.join(TEST_DATA_DIR, "pragmaA.sol")
     versions = helpers.get_pragma_versions_from_file(file)
-    assert versions == ("0.8.0", "0.8.20")
+    assert versions == ("0.8.0", "0.8.21")
     file = os.path.join(TEST_DATA_DIR, "pragmaB.sol")
     versions = helpers.get_pragma_versions_from_file(file)
-    assert versions == ("0.8.2", "0.8.20")
+    assert versions == ("0.8.2", "0.8.21")
     file = os.path.join(TEST_DATA_DIR, "pragmaC.sol")
     versions = helpers.get_pragma_versions_from_file(file)
     assert versions == ("0.8.2", "0.8.17")

--- a/diffusc/tests/unit/utils/test_network_provider.py
+++ b/diffusc/tests/unit/utils/test_network_provider.py
@@ -261,7 +261,7 @@ def test_missing_token_holders() -> None:
 def test_few_token_holders() -> None:
     rpc_url = os.getenv("GOERLI_RPC_URL")
     assert rpc_url is not None
-    net_info = NetworkInfoProvider(rpc_url, 9039011)
+    net_info = NetworkInfoProvider(rpc_url, 9029011)
     api_key = os.getenv("GOERLI_API_KEY")
     assert api_key is not None
     contract_addr = "0xae4c231A9e2D5db591540e59d6374C3D2c1a2e04"


### PR DESCRIPTION
Fix failing pytest tests with a few minor tweaks:
- In `test_helpers.test_pragma_from_file`, update the max Solidity version to 0.8.21 (the `get_pragma_from_file` function uses solc-select to get the maximum version number when the pragma statement just says `pragma solidity >=0.8.0`)
- In `test_network_provider.test_few_token_holders`, update the block number where `network_info_provider.get_token_holders` will start looking for Transfer events (I believe there was a small typo before).