### PR TITLE
Update prog name and desc for argparse

### DIFF
--- a/diffusc/diffusc.py
+++ b/diffusc/diffusc.py
@@ -29,8 +29,8 @@ def main(_args: Optional[Sequence[str]] = None) -> int:
     # Read command line arguments
 
     parser = argparse.ArgumentParser(
-        prog="diff-fuzz-upgrades",
-        description="Generate differential fuzz testing contract for comparing two upgradeable contract versions.",
+        prog="diffusc",
+        description="Differential fuzzing w/ static taint analysis for comparing two upgradeable contract versions.",
     )
 
     parser.add_argument("v1", help="The original version of the contract.")


### PR DESCRIPTION
When inputting incorrect arguments, argparse was using the old project name, i.e., `diff-fuzz-upgrades: error: ...` should be `diffusc: error: ...`