### PR TITLE
Remove dependency on echidna in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ git clone https://github.com/crytic/diffusc.git
 cd diffusc
 pip3 install .
 ```
-You will also need copy the Echidna binary from `./bin/echidna` to `/usr/local/bin` (or wherever Windows expects to find the binary) in order to fuzz with the auto-generated test contracts.
 
 ## Running Diffusc
 The minimum required arguments for running Diffusc are two contracts, provided as either file paths or addresses:

--- a/diffusc/core/echidna.py
+++ b/diffusc/core/echidna.py
@@ -2,12 +2,16 @@ import os.path
 import time
 import json
 import shutil
+from pathlib import Path
 from io import UnsupportedOperation
 from os import mkdir
 from subprocess import Popen, PIPE
 from typing import List, Tuple
 
 from diffusc.utils.crytic_print import CryticPrint
+
+
+ECHIDNA_BIN_PATH = Path(__file__).resolve().parent.parent.parent / "bin" / "echidna"
 
 
 def create_echidna_process(
@@ -18,7 +22,8 @@ def create_echidna_process(
     except OSError:
         pass
 
-    call = ["echidna"]
+    path_to_echidna_from_prefix = os.path.relpath(ECHIDNA_BIN_PATH, prefix)
+    call = [path_to_echidna_from_prefix]
     call.extend([filename])
     call.extend(["--config", config])
     call.extend(["--contract", contract])


### PR DESCRIPTION
Resolves #15 

For users who frequently use the latest version of Echidna, do not make them replace that with our custom Echidna binary every time they want to use Diffusc.

Instead, always use `./bin/echidna` in run mode.